### PR TITLE
build: fix NPM IP package incorrectly identifies some private IP addr…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6292,7 +6292,7 @@
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip": "^2.0.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {


### PR DESCRIPTION
…esses as public

The isPublic() function in the NPM package ip doesn't correctly identify certain private IP addresses in uncommon formats such as 0x7F.1 as private. Instead, it reports them as public by returning true. This can lead to security issues such as Server-Side Request Forgery (SSRF) if isPublic() is used to protect sensitive code paths when passed user input. Versions 1.1.9 and 2.0.1 fix the issue.